### PR TITLE
Added fuzzer and oss-fuzz build-script

### DIFF
--- a/libmspack/test/fuzzing/extract_fuzzer.c
+++ b/libmspack/test/fuzzing/extract_fuzzer.c
@@ -1,0 +1,45 @@
+/* This file is part of libmspack.
+ * (C) 2021 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <iostream>
+#include <mspack.h>
+
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	struct mscabd_cabinet *cab;
+	struct mscab_decompressor *cabd;
+	
+	char cab_file[256];
+	sprintf(cab_file, "/tmp/libfuzzer.cab");
+
+	FILE *fp = fopen(cab_file, "wb");
+	if (!fp)
+		return 0;
+	fwrite(data, size, 1, fp);
+	fclose(fp);
+	
+	cabd = mspack_create_cab_decompressor(NULL);
+	if(cabd==NULL){
+		return 0;
+	}
+	if(cab = cabd->open(cabd, cab_file)){
+		int err = cabd->extract(cabd, cab->files, "/tmp");
+	}
+	
+	cabd->close(cabd, cab);
+	
+	mspack_destroy_cab_decompressor(cabd);
+	std::remove(cab_file);
+	return 0;
+}

--- a/libmspack/test/fuzzing/oss_fuzz_build.sh
+++ b/libmspack/test/fuzzing/oss_fuzz_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+cd libmspack
+./autogen.sh
+./configure
+make -j$(nproc)
+
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+$CXX $CXXFLAGS -I./mspack -c $SRC/extract_fuzzer.c -o extract_fuzzer.o 
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE extract_fuzzer.o -o $OUT/extract_fuzzer fuzz_lib.a
+
+zip $OUT/extract_fuzzer_seed_corpus.zip $SRC/libmspack/libmspack/test/test_files/cabd/partial_shortfile1.cab


### PR DESCRIPTION
I have worked on setting up continuous fuzzing for libmspack, and this PR adds a fuzzer as well as the build script for oss-fuzz.

For those unfamiliar with fuzzing: Fuzzing is a way of testing software applications, whereby pseudo-random data is passed to a target application with the purpose of finding bugs and vulnerabilities. The fuzzer in this PR is implemented by way of libfuzzer.
OSS-fuzz is a project by Google that offers open source projects to integrate and have their fuzzers run continuously free of charge through regular, scheduled fuzz runs. While it is free, it is expected that founds bugs are fixed, so that the resources spent on fuzzing libmspack are put to good use.

The fuzzer creates a `.cab` file with the pseudo-random data, opens it and extracts it.

I will shortly be setting up the integration files on the OSS-fuzz side, and to complete the integration, the files in this PR need to be merged, and a maintainers email address needs to be added over at OSS-fuzz for bug reports.