### PR TITLE
Fixed runtime error and uninitialized variable usage

### DIFF
--- a/libmspack/mspack/cabd.c
+++ b/libmspack/mspack/cabd.c
@@ -1400,7 +1400,11 @@ static unsigned int cabd_checksum(unsigned char *data, unsigned int bytes,
   unsigned int len, ul = 0;
 
   for (len = bytes >> 2; len--; data += 4) {
-    cksum ^= ((data[0]) | (data[1]<<8) | (data[2]<<16) | (data[3]<<24));
+    unsigned int byte0 = data[0];
+    unsigned int byte1 = ((unsigned int)data[1]) << 8;
+    unsigned int byte2 = ((unsigned int)data[2]) << 16;
+    unsigned int byte3 = ((unsigned int)data[3]) << 24;
+    cksum ^= (byte0 | byte1 | byte2 | byte3);
   }
 
   switch (bytes & 3) {

--- a/libmspack/mspack/chmd.c
+++ b/libmspack/mspack/chmd.c
@@ -1035,11 +1035,11 @@ static int chmd_sys_write(struct mspack_file *file, void *buffer, int bytes) {
 static int chmd_init_decomp(struct mschm_decompressor_p *self,
                             struct mschmd_file *file)
 {
-  int window_size, window_bits, reset_interval, entry, err;
+  int window_size = 0, window_bits = 0, reset_interval = 0, entry = 0, err = 0;
   struct mspack_system *sys = self->system;
-  struct mschmd_sec_mscompressed *sec;
-  unsigned char *data;
-  off_t length, offset;
+  struct mschmd_sec_mscompressed *sec = NULL;
+  unsigned char *data = NULL;
+  off_t length = 0, offset = 0;
 
   sec = (struct mschmd_sec_mscompressed *) file->section;
 


### PR DESCRIPTION
I have embedded libmspack in rizin and we had these issues raised by our CI

```
+../subprojects/libmspack/libmspack/mspack/cabd.c:1403:66: runtime error: left shift of 156 by 24 places cannot be represented in type 'int'
../subprojects/libmspack/libmspack/mspack/chmd.c: In function ‘chmd_extract’:
../subprojects/libmspack/libmspack/mspack/chmd.c:1139:10: error: ‘length’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
1139 |   length -= self->d->offset;
     |          ^~
../subprojects/libmspack/libmspack/mspack/chmd.c:1042:9: note: ‘length’ was declared here
1042 |   off_t length, offset;
     |         ^~~~~~
cc1: all warnings being treated as errors
```

If interested i have a working meson configuration for the project.