### PR TITLE
Use memmove for overlapping buffer

### DIFF
--- a/libmspack/test/md5.c
+++ b/libmspack/test/md5.c
@@ -278,7 +278,7 @@ md5_process_bytes ( const void *buffer, size_t len, struct md5_ctx *ctx)
         {
           md5_process_block (ctx->buffer, 64, ctx);
           left_over -= 64;
-          memcpy (ctx->buffer, &ctx->buffer[64], left_over);
+          memmove (ctx->buffer, &ctx->buffer[64], left_over);
         }
       ctx->buflen = left_over;
     }


### PR DESCRIPTION
Coverity found the following test where `memcpy` is used to copy an overlapping buffer.  `memmove` should be used instead.
```
Error: BUFFER_SIZE (CWE-474):
libmspack-0.10.1alpha/test/md5.c:281: overlapping_buffer: The source buffer "&ctx->buffer[64]" potentially overlaps with the destination buffer "ctx->buffer", which results in undefined behavior for "memcpy". libmspack-0.10.1alpha/test/md5.c:281: remediation: Use memmove instead of "memcpy".
  279|             md5_process_block (ctx->buffer, 64, ctx);
  280|             left_over -= 64;
  281|->           memcpy (ctx->buffer, &ctx->buffer[64], left_over);
  282|           }
  283|         ctx->buflen = left_over;
```